### PR TITLE
Add HA iOS NextAlarm integration

### DIFF
--- a/custom_components/ha_ios_nextalarm/__init__.py
+++ b/custom_components/ha_ios_nextalarm/__init__.py
@@ -1,0 +1,52 @@
+"""HA iOS NextAlarm integration setup."""
+
+from __future__ import annotations
+
+import logging
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+from .const import DOMAIN, PLATFORMS
+from .coordinator import NextAlarmCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup(hass: HomeAssistant, config: dict) -> bool:
+    """Set up the HA iOS NextAlarm integration."""
+
+    hass.data.setdefault(DOMAIN, {})
+    return True
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up HA iOS NextAlarm from a config entry."""
+
+    coordinator = NextAlarmCoordinator(hass, entry)
+    await coordinator.async_setup()
+    hass.data[DOMAIN][entry.entry_id] = coordinator
+    entry.async_on_unload(entry.add_update_listener(_async_update_listener))
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    _LOGGER.debug("HA iOS NextAlarm entry %s set up", entry.entry_id)
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a config entry."""
+
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    if not unload_ok:
+        return False
+    coordinator: NextAlarmCoordinator = hass.data[DOMAIN].pop(entry.entry_id)
+    await coordinator.async_unload()
+    if not hass.data[DOMAIN]:
+        hass.data.pop(DOMAIN)
+    _LOGGER.debug("HA iOS NextAlarm entry %s unloaded", entry.entry_id)
+    return True
+
+
+async def _async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Handle options update by reloading the config entry."""
+
+    await hass.config_entries.async_reload(entry.entry_id)

--- a/custom_components/ha_ios_nextalarm/config_flow.py
+++ b/custom_components/ha_ios_nextalarm/config_flow.py
@@ -1,0 +1,94 @@
+"""Config flow for the HA iOS NextAlarm integration."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import voluptuous as vol
+
+from homeassistant import config_entries
+from homeassistant.core import callback
+from homeassistant.data_entry_flow import FlowResult
+
+from .const import (
+    CONF_WEEKDAY_CUSTOM_MAP,
+    CONF_WEEKDAY_LOCALE,
+    DEFAULT_OPTIONS,
+    DOMAIN,
+    OPTION_WEEKDAY_LOCALES,
+)
+from . import helpers
+
+
+class NextAlarmConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle the config flow."""
+
+    VERSION = 1
+
+    async def async_step_user(self, user_input: dict[str, Any] | None = None) -> FlowResult:
+        """Handle the initial step."""
+
+        if self._async_current_entries():
+            return self.async_abort(reason="single_instance_allowed")
+
+        if user_input is not None:
+            return self.async_create_entry(
+                title="HA iOS NextAlarm",
+                data={},
+                options=dict(DEFAULT_OPTIONS),
+            )
+
+        return self.async_show_form(step_id="user")
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(config_entry: config_entries.ConfigEntry) -> config_entries.OptionsFlow:
+        return NextAlarmOptionsFlow(config_entry)
+
+
+class NextAlarmOptionsFlow(config_entries.OptionsFlow):
+    """Options flow for NextAlarm."""
+
+    def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
+        self.config_entry = config_entry
+
+    async def async_step_init(self, user_input: dict[str, Any] | None = None) -> FlowResult:
+        """Manage the options."""
+
+        errors: dict[str, str] = {}
+        current = dict(DEFAULT_OPTIONS)
+        current.update(self.config_entry.options)
+
+        if user_input is not None:
+            locale = user_input[CONF_WEEKDAY_LOCALE]
+            custom_map = user_input.get(
+                CONF_WEEKDAY_CUSTOM_MAP, DEFAULT_OPTIONS[CONF_WEEKDAY_CUSTOM_MAP]
+            )
+            _, map_errors = helpers.build_weekday_maps(custom_map)
+            if map_errors:
+                errors["base"] = "invalid_custom_map"
+            else:
+                return self.async_create_entry(
+                    data={
+                        CONF_WEEKDAY_LOCALE: locale,
+                        CONF_WEEKDAY_CUSTOM_MAP: custom_map,
+                    }
+                )
+
+        locales = list(OPTION_WEEKDAY_LOCALES)
+        if current[CONF_WEEKDAY_LOCALE] not in locales:
+            locales.append(current[CONF_WEEKDAY_LOCALE])
+
+        schema = vol.Schema(
+            {
+                vol.Required(CONF_WEEKDAY_LOCALE, default=current[CONF_WEEKDAY_LOCALE]): vol.In(
+                    locales
+                ),
+                vol.Optional(
+                    CONF_WEEKDAY_CUSTOM_MAP,
+                    default=current[CONF_WEEKDAY_CUSTOM_MAP],
+                ): str,
+            }
+        )
+
+        return self.async_show_form(step_id="init", data_schema=schema, errors=errors)

--- a/custom_components/ha_ios_nextalarm/const.py
+++ b/custom_components/ha_ios_nextalarm/const.py
@@ -1,0 +1,75 @@
+"""Constants for the HA iOS NextAlarm integration."""
+
+from __future__ import annotations
+
+from typing import Final
+
+from homeassistant.const import Platform
+
+DOMAIN: Final = "ha_ios_nextalarm"
+PLATFORMS: Final = [Platform.SENSOR]
+EVENT_NEXT_ALARM: Final = "ha_ios_nextalarm"
+
+STORAGE_VERSION: Final = 1
+STORAGE_KEY: Final = DOMAIN
+
+SIGNAL_PERSON_UPDATED: Final = f"{DOMAIN}_person_updated"
+
+CONF_WEEKDAY_LOCALE: Final = "weekday_locale"
+CONF_WEEKDAY_CUSTOM_MAP: Final = "weekday_custom_map"
+
+DEFAULT_WEEKDAY_LOCALE: Final = "auto"
+DEFAULT_CUSTOM_MAP: Final = "{}"
+DEFAULT_OPTIONS: Final = {
+    CONF_WEEKDAY_LOCALE: DEFAULT_WEEKDAY_LOCALE,
+    CONF_WEEKDAY_CUSTOM_MAP: DEFAULT_CUSTOM_MAP,
+}
+
+MAP_VERSION: Final = 1
+
+STR_ONOFF: Final = {"on": True, "off": False}
+
+WEEKDAY_MAPS: Final = {
+    "en": {
+        "monday": 0,
+        "mon": 0,
+        "tuesday": 1,
+        "tue": 1,
+        "wednesday": 2,
+        "wed": 2,
+        "thursday": 3,
+        "thu": 3,
+        "friday": 4,
+        "fri": 4,
+        "saturday": 5,
+        "sat": 5,
+        "sunday": 6,
+        "sun": 6,
+    },
+    "pl": {
+        "poniedzialek": 0,
+        "pon": 0,
+        "poniedziałek": 0,
+        "wtorek": 1,
+        "wt": 1,
+        "sroda": 2,
+        "środa": 2,
+        "sr": 2,
+        "czwartek": 3,
+        "czw": 3,
+        "piatek": 4,
+        "piątek": 4,
+        "pt": 4,
+        "sobota": 5,
+        "sob": 5,
+        "niedziela": 6,
+        "nd": 6,
+        "nie": 6,
+    },
+}
+
+OPTION_WEEKDAY_LOCALES: Final = [DEFAULT_WEEKDAY_LOCALE, *sorted(WEEKDAY_MAPS)]
+
+ATTR_NOTE: Final = "note"
+
+PREVIEW_LIMIT: Final = 5

--- a/custom_components/ha_ios_nextalarm/coordinator.py
+++ b/custom_components/ha_ios_nextalarm/coordinator.py
@@ -1,0 +1,346 @@
+"""Coordinator for HA iOS NextAlarm integration."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta
+import logging
+from typing import Any
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import CALLBACK_TYPE, Event, HomeAssistant, callback
+from homeassistant.helpers.dispatcher import async_dispatcher_send
+from homeassistant.helpers.event import async_track_point_in_time
+from homeassistant.helpers.storage import Store
+from homeassistant.util import dt as dt_util
+from homeassistant.util.slugify import slugify
+
+from .const import (
+    CONF_WEEKDAY_CUSTOM_MAP,
+    CONF_WEEKDAY_LOCALE,
+    DEFAULT_OPTIONS,
+    EVENT_NEXT_ALARM,
+    MAP_VERSION,
+    SIGNAL_PERSON_UPDATED,
+    STORAGE_KEY,
+    STORAGE_VERSION,
+)
+from . import helpers
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class PersonState:
+    """Runtime state for a person."""
+
+    slug: str
+    person: str
+    normalized_alarms: dict[str, helpers.NormalizedAlarm] = field(default_factory=dict)
+    parse_errors: list[str] = field(default_factory=list)
+    map_errors: list[str] = field(default_factory=list)
+    map_locale: str | None = None
+    last_event_time: datetime | None = None
+    raw_event: dict[str, Any] | None = None
+    next_alarm_key: str | None = None
+    next_alarm_time: datetime | None = None
+    note: str | None = None
+    schedule: dict[str, datetime | None] = field(default_factory=dict)
+    timer_cancel: CALLBACK_TYPE | None = None
+    map_version: int = MAP_VERSION
+
+    def as_dict(self) -> dict[str, Any]:
+        """Return a dictionary representation safe for storage."""
+
+        return {
+            "person": self.person,
+            "normalized_alarms": {
+                key: alarm.to_dict() for key, alarm in self.normalized_alarms.items()
+            },
+            "parse_errors": list(self.parse_errors),
+            "map_errors": list(self.map_errors),
+            "map_locale": self.map_locale,
+            "last_event_time": self.last_event_time.isoformat()
+            if self.last_event_time
+            else None,
+            "raw_event": self.raw_event,
+            "next_alarm_key": self.next_alarm_key,
+            "next_alarm_time": self.next_alarm_time.isoformat()
+            if self.next_alarm_time
+            else None,
+            "note": self.note,
+            "schedule": {
+                key: value.isoformat() if value else None
+                for key, value in self.schedule.items()
+            },
+            "map_version": self.map_version,
+        }
+
+    @classmethod
+    def from_dict(cls, slug: str, data: dict[str, Any]) -> "PersonState":
+        """Restore a person state from storage."""
+
+        normalized_alarms = {
+            key: helpers.NormalizedAlarm.from_dict(value)
+            for key, value in data.get("normalized_alarms", {}).items()
+        }
+        last_event_time = dt_util.parse_datetime(data.get("last_event_time"))
+        next_alarm_time = dt_util.parse_datetime(data.get("next_alarm_time"))
+        schedule: dict[str, datetime | None] = {}
+        for key, value in data.get("schedule", {}).items():
+            schedule[key] = dt_util.parse_datetime(value) if value else None
+        return cls(
+            slug=slug,
+            person=str(data.get("person", slug)),
+            normalized_alarms=normalized_alarms,
+            parse_errors=list(data.get("parse_errors", [])),
+            map_errors=list(data.get("map_errors", [])),
+            map_locale=data.get("map_locale"),
+            last_event_time=last_event_time,
+            raw_event=data.get("raw_event"),
+            next_alarm_key=data.get("next_alarm_key"),
+            next_alarm_time=next_alarm_time,
+            note=data.get("note"),
+            schedule=schedule,
+            map_version=int(data.get("map_version", MAP_VERSION)),
+        )
+
+
+class NextAlarmCoordinator:
+    """Coordinator responsible for processing incoming events."""
+
+    def __init__(self, hass: HomeAssistant, entry: ConfigEntry) -> None:
+        """Initialise the coordinator."""
+
+        self.hass = hass
+        self.entry = entry
+        self._store = Store(hass, STORAGE_VERSION, f"{STORAGE_KEY}_{entry.entry_id}")
+        self._person_states: dict[str, PersonState] = {}
+        self._person_listeners: list[Callable[[str], None]] = []
+        self._remove_listener: CALLBACK_TYPE | None = None
+        self._lock = asyncio.Lock()
+
+    @property
+    def persons(self) -> list[str]:
+        """Return the known person identifiers."""
+
+        return list(self._person_states)
+
+    def get_person_state(self, slug: str) -> PersonState | None:
+        """Return the state for a given person."""
+
+        return self._person_states.get(slug)
+
+    def signal_person(self, slug: str) -> str:
+        """Return the dispatcher signal for a person."""
+
+        return f"{SIGNAL_PERSON_UPDATED}_{self.entry.entry_id}_{slug}"
+
+    async def async_setup(self) -> None:
+        """Set up the coordinator."""
+
+        await self._async_load_storage()
+        self._remove_listener = self.hass.bus.async_listen(
+            EVENT_NEXT_ALARM, self._async_handle_event
+        )
+        _LOGGER.debug("Listening for %s events", EVENT_NEXT_ALARM)
+
+    async def async_unload(self) -> None:
+        """Tear down the coordinator."""
+
+        if self._remove_listener:
+            self._remove_listener()
+            self._remove_listener = None
+        for state in self._person_states.values():
+            if state.timer_cancel:
+                state.timer_cancel()
+                state.timer_cancel = None
+        await self._store.async_save(self._storage_payload())
+
+    def async_add_person_listener(self, listener: Callable[[str], None]) -> Callable[[], None]:
+        """Register a callback for new persons."""
+
+        self._person_listeners.append(listener)
+        for slug in self._person_states:
+            listener(slug)
+
+        def _remove() -> None:
+            self._person_listeners.remove(listener)
+
+        return _remove
+
+    async def _async_load_storage(self) -> None:
+        """Load previously stored state."""
+
+        data = await self._store.async_load()
+        if not data:
+            return
+        persons: dict[str, Any] = data.get("persons", {})
+        for slug, stored in persons.items():
+            try:
+                state = PersonState.from_dict(slug, stored)
+            except Exception as err:  # pragma: no cover - safety net
+                _LOGGER.warning("Failed to restore state for %s: %s", slug, err)
+                continue
+            self._person_states[slug] = state
+            reference_now = dt_util.utcnow()
+            if state.next_alarm_time and reference_now <= state.next_alarm_time:
+                near_time = state.next_alarm_time - timedelta(seconds=1)
+                computation = helpers.compute_next_alarm(
+                    state.normalized_alarms, near_time, self._timezone
+                )
+                state.next_alarm_key = computation.alarm.key if computation.alarm else None
+                state.next_alarm_time = computation.next_time
+                state.note = computation.note
+                state.schedule = computation.schedule
+            else:
+                self._refresh_schedule(state, reference_time=reference_now)
+            self._schedule_rollover(state)
+
+    @property
+    def _timezone(self):
+        tz_name = self.hass.config.time_zone
+        timezone = dt_util.get_time_zone(tz_name) if tz_name else None
+        return timezone or dt_util.UTC
+
+    def _current_options(self) -> dict[str, Any]:
+        options = dict(DEFAULT_OPTIONS)
+        options.update(self.entry.options)
+        return options
+
+    async def _async_handle_event(self, event: Event) -> None:
+        """Handle an incoming NextAlarm event."""
+
+        async with self._lock:
+            await self._async_process_event(event)
+
+    async def _async_process_event(self, event: Event) -> None:
+        person_raw = event.data.get("person")
+        if not person_raw:
+            _LOGGER.warning("Received %s event without person", EVENT_NEXT_ALARM)
+            return
+        alarms = event.data.get("alarms")
+        if not isinstance(alarms, dict):
+            _LOGGER.warning("Event for %s does not contain alarm dictionary", person_raw)
+            return
+
+        slug = slugify(str(person_raw)) or str(person_raw).strip().casefold()
+        if slug not in self._person_states:
+            self._person_states[slug] = PersonState(slug=slug, person=str(person_raw))
+            self._notify_new_person(slug)
+        state = self._person_states[slug]
+        state.person = str(person_raw)
+
+        options = self._current_options()
+        maps, map_errors = helpers.build_weekday_maps(
+            options.get(CONF_WEEKDAY_CUSTOM_MAP, DEFAULT_OPTIONS[CONF_WEEKDAY_CUSTOM_MAP])
+        )
+        if map_errors:
+            _LOGGER.warning("Custom weekday map issues: \n%s", "\n".join(map_errors))
+
+        normalized = helpers.normalize_event(
+            alarms=alarms,
+            tzinfo=self._timezone,
+            locale_option=options.get(CONF_WEEKDAY_LOCALE, DEFAULT_OPTIONS[CONF_WEEKDAY_LOCALE]),
+            maps=maps,
+            map_errors=map_errors,
+        )
+        now = dt_util.utcnow()
+        computation = helpers.compute_next_alarm(
+            normalized.alarms, now, self._timezone
+        )
+
+        state.normalized_alarms = normalized.alarms
+        state.parse_errors = normalized.parse_errors
+        state.map_errors = list(normalized.map_errors)
+        state.map_locale = normalized.map_locale
+        state.last_event_time = event.time_fired
+        state.next_alarm_key = computation.alarm.key if computation.alarm else None
+        state.next_alarm_time = computation.next_time
+        state.note = computation.note
+        state.schedule = computation.schedule
+        state.map_version = MAP_VERSION
+        state.raw_event = {
+            "event_type": event.event_type,
+            "origin": event.origin,
+            "time_fired": event.time_fired.isoformat(),
+            "context": helpers.ensure_serializable(event.context.as_dict()),
+            "data": helpers.ensure_serializable(event.data),
+        }
+
+        self._schedule_rollover(state)
+        await self._store.async_save(self._storage_payload())
+        _LOGGER.debug(
+            "Processed NextAlarm event for %s; next alarm %s",
+            state.person,
+            state.next_alarm_time,
+        )
+        self._notify_person_update(slug)
+
+    def _notify_new_person(self, slug: str) -> None:
+        for listener in list(self._person_listeners):
+            listener(slug)
+
+    def _notify_person_update(self, slug: str) -> None:
+        async_dispatcher_send(self.hass, self.signal_person(slug))
+
+    def _schedule_rollover(self, state: PersonState) -> None:
+        if state.timer_cancel:
+            state.timer_cancel()
+            state.timer_cancel = None
+        if not state.next_alarm_time:
+            return
+
+        @callback
+        def _fire(now: datetime) -> None:
+            self.hass.async_create_task(self._async_rollover(state.slug, now))
+
+        state.timer_cancel = async_track_point_in_time(
+            self.hass, _fire, state.next_alarm_time
+        )
+
+    async def _async_rollover(self, slug: str, trigger_time: datetime | None = None) -> None:
+        state = self._person_states.get(slug)
+        if not state:
+            return
+        state.timer_cancel = None
+        self._refresh_schedule(state, reference_time=trigger_time)
+        self._schedule_rollover(state)
+        await self._store.async_save(self._storage_payload())
+        _LOGGER.debug("Rollover executed for %s", state.person)
+        self._notify_person_update(slug)
+
+    def _refresh_schedule(self, state: PersonState, reference_time: datetime | None = None) -> None:
+        if not state.normalized_alarms:
+            state.next_alarm_key = None
+            state.next_alarm_time = None
+            state.note = "no_alarms"
+            state.schedule = {}
+            return
+        now = reference_time or dt_util.utcnow()
+        computation = helpers.compute_next_alarm(
+            state.normalized_alarms, now, self._timezone
+        )
+        state.next_alarm_key = computation.alarm.key if computation.alarm else None
+        state.next_alarm_time = computation.next_time
+        state.note = computation.note
+        state.schedule = computation.schedule
+        state.map_version = MAP_VERSION
+
+    def build_preview(self, state: PersonState) -> list[dict[str, Any]]:
+        """Expose helper for diagnostics sensor."""
+
+        return helpers.build_normalized_preview(state.normalized_alarms, state.schedule)
+
+    def describe_time_until(self, state: PersonState) -> str | None:
+        """Return a human-friendly delta for the next alarm."""
+
+        return helpers.describe_time_until(state.next_alarm_time)
+
+    def time_zone(self):
+        return self._timezone
+
+    def _storage_payload(self) -> dict[str, Any]:
+        return {"persons": {slug: state.as_dict() for slug, state in self._person_states.items()}}

--- a/custom_components/ha_ios_nextalarm/helpers.py
+++ b/custom_components/ha_ios_nextalarm/helpers.py
@@ -1,0 +1,481 @@
+"""Helper utilities for the HA iOS NextAlarm integration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta, time
+import json
+import logging
+import unicodedata
+from typing import Any, Mapping, Sequence
+
+from homeassistant.util import dt as dt_util
+
+from .const import PREVIEW_LIMIT, STR_ONOFF, WEEKDAY_MAPS
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class NormalizedAlarm:
+    """Representation of a normalized alarm received from an event."""
+
+    key: str
+    label: str
+    enabled: bool
+    repeat: bool
+    snooze: bool
+    base_time: datetime
+    repeat_days_localized: list[str]
+    repeat_days_normalized: list[int]
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize the alarm into a JSON-friendly dictionary."""
+
+        return {
+            "key": self.key,
+            "label": self.label,
+            "enabled": self.enabled,
+            "repeat": self.repeat,
+            "snooze": self.snooze,
+            "base_time": self.base_time.isoformat(),
+            "repeat_days_localized": list(self.repeat_days_localized),
+            "repeat_days_normalized": list(self.repeat_days_normalized),
+        }
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "NormalizedAlarm":
+        """Deserialize an alarm from storage."""
+
+        base_time_str = data["base_time"]
+        base_time = dt_util.parse_datetime(base_time_str)
+        if base_time is None:
+            raise ValueError(f"Invalid datetime stored: {base_time_str}")
+        return cls(
+            key=str(data["key"]),
+            label=str(data.get("label", "")),
+            enabled=bool(data.get("enabled", False)),
+            repeat=bool(data.get("repeat", False)),
+            snooze=bool(data.get("snooze", False)),
+            base_time=base_time,
+            repeat_days_localized=list(data.get("repeat_days_localized", [])),
+            repeat_days_normalized=list(data.get("repeat_days_normalized", [])),
+        )
+
+
+@dataclass(slots=True)
+class NormalizedEvent:
+    """Container for normalized event data."""
+
+    alarms: dict[str, NormalizedAlarm]
+    map_locale: str
+    parse_errors: list[str]
+    map_errors: list[str]
+
+
+@dataclass(slots=True)
+class NextAlarmComputation:
+    """Result of evaluating the next alarm for a person."""
+
+    alarm: NormalizedAlarm | None
+    next_time: datetime | None
+    schedule: dict[str, datetime | None]
+    note: str | None
+
+
+def normalize_day_key(value: str) -> str:
+    """Normalize weekday names for lookup."""
+
+    normalized = unicodedata.normalize("NFKD", value or "")
+    stripped = "".join(ch for ch in normalized if not unicodedata.combining(ch))
+    return stripped.replace(" ", "").replace("-", "").casefold().strip()
+
+
+def _localize(naive: datetime, tzinfo) -> datetime:
+    """Attach a timezone to a naive datetime."""
+
+    if hasattr(tzinfo, "localize"):
+        return tzinfo.localize(naive)
+    return naive.replace(tzinfo=tzinfo)
+
+
+def parse_alarm_datetime(value: str, tzinfo) -> datetime:
+    """Parse the alarm datetime string into an aware datetime."""
+
+    text = (value or "").strip()
+    if not text:
+        raise ValueError("missing datetime value")
+
+    # Primary format: 24-hour clock "dd.MM.yyyy HH:mm"
+    try:
+        naive = datetime.strptime(text, "%d.%m.%Y %H:%M")
+    except ValueError:
+        upper = text.upper()
+        if "AM" in upper or "PM" in upper:
+            try:
+                naive = datetime.strptime(text, "%m/%d/%Y %I:%M %p")
+            except ValueError as exc:
+                raise ValueError(f"unsupported datetime format: {text}") from exc
+        else:
+            raise ValueError(f"unsupported datetime format: {text}")
+    return _localize(naive, tzinfo)
+
+
+def parse_on_off(value: Any, *, field: str, alarm_key: str, errors: list[str]) -> bool | None:
+    """Parse an on/off value."""
+
+    if isinstance(value, str):
+        normalized = value.strip().casefold()
+        if normalized in STR_ONOFF:
+            return STR_ONOFF[normalized]
+    elif isinstance(value, bool):
+        return value
+    errors.append(f"Alarm {alarm_key}: invalid value '{value}' for field '{field}'")
+    return None
+
+
+def build_weekday_maps(custom_map_json: str) -> tuple[dict[str, dict[str, int]], list[str]]:
+    """Build locale weekday maps from defaults and an optional JSON override."""
+
+    base: dict[str, dict[str, int]] = {
+        locale: {normalize_day_key(key): value for key, value in mapping.items()}
+        for locale, mapping in WEEKDAY_MAPS.items()
+    }
+    if not custom_map_json or not custom_map_json.strip():
+        return base, []
+
+    errors: list[str] = []
+    try:
+        parsed = json.loads(custom_map_json)
+    except json.JSONDecodeError as err:
+        errors.append(f"Invalid custom map JSON: {err}")
+        return base, errors
+    if not isinstance(parsed, Mapping):
+        errors.append("Custom map must be a JSON object")
+        return base, errors
+
+    for locale, mapping in parsed.items():
+        if not isinstance(locale, str):
+            errors.append("Custom map locale keys must be strings")
+            continue
+        if not isinstance(mapping, Mapping):
+            errors.append(f"Custom map for locale '{locale}' must be an object")
+            continue
+        normalized_mapping: dict[str, int] = base.get(locale, {}).copy()
+        for day_name, index in mapping.items():
+            if not isinstance(day_name, str):
+                errors.append(
+                    f"Custom map for locale '{locale}' has non-string key '{day_name}'"
+                )
+                continue
+            try:
+                weekday_index = int(index)
+            except (TypeError, ValueError) as err:
+                errors.append(
+                    f"Custom map value for '{day_name}' in locale '{locale}' is not an integer: {index}"
+                )
+                continue
+            if weekday_index < 0 or weekday_index > 6:
+                errors.append(
+                    f"Custom map value for '{day_name}' in locale '{locale}' must be between 0 and 6"
+                )
+                continue
+            normalized_mapping[normalize_day_key(day_name)] = weekday_index
+        base[locale] = normalized_mapping
+    return base, errors
+
+
+def detect_weekday_locale(
+    weekday_lines: Sequence[str],
+    locale_option: str,
+    maps: Mapping[str, Mapping[str, int]],
+) -> str:
+    """Detect the best matching weekday locale."""
+
+    default_locale = next(iter(maps))
+    if locale_option != "auto":
+        return locale_option if locale_option in maps else default_locale
+    if not weekday_lines:
+        return default_locale
+
+    best_locale = None
+    best_score = -1
+    normalized_lines = [normalize_day_key(item) for item in weekday_lines]
+    for locale, mapping in maps.items():
+        score = sum(1 for item in normalized_lines if item in mapping)
+        if score > best_score:
+            best_locale = locale
+            best_score = score
+    if best_locale is None:
+        return default_locale
+    return best_locale
+
+
+def normalize_repeat_days(
+    raw: Any,
+    *,
+    alarm_key: str,
+    locale_option: str,
+    maps: Mapping[str, Mapping[str, int]],
+    errors: list[str],
+) -> tuple[list[str], list[int], str]:
+    """Normalize repeat day values."""
+
+    text = str(raw or "")
+    lines = [line.strip() for line in text.splitlines() if line.strip()]
+    locale = detect_weekday_locale(lines, locale_option, maps)
+    normalized_days: list[int] = []
+    localized_days: list[str] = []
+    seen: set[int] = set()
+
+    if not lines:
+        return localized_days, normalized_days, locale
+
+    mapping = maps.get(locale, {})
+    fallback_maps = [mapping] + [maps[name] for name in maps if name != locale]
+
+    for line in lines:
+        normalized_line = normalize_day_key(line)
+        matched = False
+        for candidate_map in fallback_maps:
+            if normalized_line in candidate_map:
+                weekday_index = candidate_map[normalized_line]
+                if weekday_index not in seen:
+                    seen.add(weekday_index)
+                    normalized_days.append(weekday_index)
+                    localized_days.append(line)
+                matched = True
+                break
+        if not matched:
+            errors.append(
+                f"Alarm {alarm_key}: could not map repeat day '{line}' with locale '{locale}'"
+            )
+    return localized_days, normalized_days, locale
+
+
+def normalize_event(
+    *,
+    alarms: Mapping[str, Mapping[str, Any]],
+    tzinfo,
+    locale_option: str,
+    maps: Mapping[str, Mapping[str, int]],
+    map_errors: Sequence[str] | None = None,
+) -> NormalizedEvent:
+    """Normalize the alarm payload of an event."""
+
+    parse_errors: list[str] = []
+    normalized_alarms: dict[str, NormalizedAlarm] = {}
+    all_repeat_lines: list[str] = []
+
+    for alarm in alarms.values():
+        raw_days = alarm.get("Repeat Days")
+        if isinstance(raw_days, str):
+            all_repeat_lines.extend(
+                [line.strip() for line in raw_days.splitlines() if line.strip()]
+            )
+
+    map_locale = detect_weekday_locale(all_repeat_lines, locale_option, maps)
+
+    for key, raw_alarm in alarms.items():
+        label = str(raw_alarm.get("Label", "")).strip() or str(key)
+        raw_date = raw_alarm.get("Date")
+        if raw_date is None:
+            parse_errors.append(f"Alarm {key}: missing Date")
+            continue
+        try:
+            base_time = parse_alarm_datetime(str(raw_date), tzinfo)
+        except ValueError as err:
+            parse_errors.append(f"Alarm {key}: {err}")
+            continue
+
+        state = parse_on_off(raw_alarm.get("State"), field="State", alarm_key=str(key), errors=parse_errors)
+        if state is None:
+            continue
+        repeat = parse_on_off(raw_alarm.get("Repeat"), field="Repeat", alarm_key=str(key), errors=parse_errors)
+        if repeat is None:
+            continue
+        snooze = parse_on_off(raw_alarm.get("Snooze"), field="Snooze", alarm_key=str(key), errors=parse_errors)
+        if snooze is None:
+            continue
+
+        repeat_days_localized: list[str] = []
+        repeat_days_normalized: list[int] = []
+        if repeat:
+            (
+                repeat_days_localized,
+                repeat_days_normalized,
+                _,
+            ) = normalize_repeat_days(
+                raw_alarm.get("Repeat Days", ""),
+                alarm_key=str(key),
+                locale_option=map_locale,
+                maps=maps,
+                errors=parse_errors,
+            )
+            if not repeat_days_normalized:
+                parse_errors.append(
+                    f"Alarm {key}: repeat is enabled but no valid repeat days were provided"
+                )
+                continue
+
+        normalized_alarms[str(key)] = NormalizedAlarm(
+            key=str(key),
+            label=label,
+            enabled=state,
+            repeat=repeat,
+            snooze=snooze,
+            base_time=base_time,
+            repeat_days_localized=repeat_days_localized,
+            repeat_days_normalized=repeat_days_normalized,
+        )
+
+    return NormalizedEvent(
+        alarms=normalized_alarms,
+        map_locale=map_locale,
+        parse_errors=parse_errors,
+        map_errors=list(map_errors or []),
+    )
+
+
+def compute_alarm_schedule(
+    alarms: Mapping[str, NormalizedAlarm], now: datetime, tzinfo
+) -> dict[str, datetime | None]:
+    """Compute the next trigger per alarm."""
+
+    schedule: dict[str, datetime | None] = {}
+    for key, alarm in alarms.items():
+        schedule[key] = compute_single_alarm_next(alarm, now, tzinfo)
+    return schedule
+
+
+def compute_single_alarm_next(
+    alarm: NormalizedAlarm, now: datetime, tzinfo
+) -> datetime | None:
+    """Compute the next occurrence for a single alarm."""
+
+    if not alarm.enabled:
+        return None
+
+    if not alarm.repeat:
+        return alarm.base_time if alarm.base_time > now else None
+
+    if not alarm.repeat_days_normalized:
+        return None
+
+    local_now = now.astimezone(tzinfo)
+    local_today = local_now.date()
+    base_local = alarm.base_time.astimezone(tzinfo)
+    base_time_components = time(
+        hour=base_local.hour,
+        minute=base_local.minute,
+        second=base_local.second,
+        microsecond=base_local.microsecond,
+    )
+
+    for offset in range(0, 8):
+        candidate_date = local_today + timedelta(days=offset)
+        weekday = candidate_date.weekday()
+        if weekday not in alarm.repeat_days_normalized:
+            continue
+        candidate_naive = datetime.combine(candidate_date, base_time_components)
+        candidate = _localize(candidate_naive, tzinfo)
+        if candidate > now:
+            return candidate
+    return None
+
+
+def compute_next_alarm(
+    alarms: Mapping[str, NormalizedAlarm], now: datetime, tzinfo
+) -> NextAlarmComputation:
+    """Compute the next alarm selection."""
+
+    schedule = compute_alarm_schedule(alarms, now, tzinfo)
+    next_alarm: NormalizedAlarm | None = None
+    next_time: datetime | None = None
+
+    for key in sorted(alarms):
+        candidate_time = schedule.get(key)
+        if candidate_time is None:
+            continue
+        if next_time is None or candidate_time < next_time:
+            next_time = candidate_time
+            next_alarm = alarms[key]
+
+    note: str | None = None
+    if not alarms:
+        note = "no_alarms"
+    elif all(not alarm.enabled for alarm in alarms.values()):
+        note = "no_enabled"
+    elif next_time is None:
+        note = "no_future"
+
+    return NextAlarmComputation(
+        alarm=next_alarm,
+        next_time=next_time,
+        schedule=schedule,
+        note=note,
+    )
+
+
+def build_normalized_preview(
+    alarms: Mapping[str, NormalizedAlarm],
+    schedule: Mapping[str, datetime | None],
+) -> list[dict[str, Any]]:
+    """Build a truncated preview for diagnostics."""
+
+    preview: list[dict[str, Any]] = []
+    for key in sorted(alarms):
+        alarm = alarms[key]
+        next_time = schedule.get(key)
+        preview.append(
+            {
+                "key": alarm.key,
+                "label": alarm.label,
+                "enabled": alarm.enabled,
+                "repeat": alarm.repeat,
+                "repeat_days": list(alarm.repeat_days_normalized),
+                "next": next_time.isoformat() if next_time else None,
+            }
+        )
+        if len(preview) >= PREVIEW_LIMIT:
+            break
+    return preview
+
+
+def describe_time_until(target: datetime | None, now: datetime | None = None) -> str | None:
+    """Return a human-friendly description of the time until target."""
+
+    if target is None:
+        return None
+    reference = now or dt_util.utcnow()
+    delta = target - reference
+    total_seconds = int(delta.total_seconds())
+    if total_seconds <= 0:
+        return "due"
+    parts: list[str] = []
+    days, remainder = divmod(total_seconds, 86400)
+    hours, remainder = divmod(remainder, 3600)
+    minutes, seconds = divmod(remainder, 60)
+    if days:
+        parts.append(f"{days}d")
+    if hours:
+        parts.append(f"{hours}h")
+    if minutes:
+        parts.append(f"{minutes}m")
+    if not parts:
+        parts.append(f"{seconds}s")
+    return f"in {' '.join(parts)}"
+
+
+def ensure_serializable(value: Any) -> Any:
+    """Convert arbitrary event data into JSON-serialisable objects."""
+
+    if isinstance(value, dict):
+        return {str(key): ensure_serializable(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple, set)):
+        return [ensure_serializable(item) for item in value]
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, (str, int, float, bool)) or value is None:
+        return value
+    return str(value)

--- a/custom_components/ha_ios_nextalarm/manifest.json
+++ b/custom_components/ha_ios_nextalarm/manifest.json
@@ -1,0 +1,11 @@
+{
+  "domain": "ha_ios_nextalarm",
+  "name": "HA iOS NextAlarm",
+  "version": "0.1.0",
+  "integration_type": "hub",
+  "iot_class": "local_push",
+  "config_flow": true,
+  "documentation": "https://github.com/example/ha-ios-nextalarm",
+  "requirements": [],
+  "codeowners": ["@example"]
+}

--- a/custom_components/ha_ios_nextalarm/sensor.py
+++ b/custom_components/ha_ios_nextalarm/sensor.py
@@ -1,0 +1,197 @@
+"""Sensor entities for the HA iOS NextAlarm integration."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from homeassistant.components.sensor import SensorDeviceClass, SensorEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.helpers.restore_state import RestoreEntity
+from homeassistant.util.slugify import slugify
+
+from .const import ATTR_NOTE, DOMAIN, MAP_VERSION
+from .coordinator import NextAlarmCoordinator, PersonState
+from .helpers import build_normalized_preview, describe_time_until
+
+NOTE_MESSAGES = {
+    "no_alarms": "No alarms provided",
+    "no_enabled": "No enabled alarms",
+    "no_future": "No future alarms",
+    "waiting": "Waiting for first event",
+}
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities
+) -> None:
+    """Set up NextAlarm sensors for a config entry."""
+
+    coordinator: NextAlarmCoordinator = hass.data[DOMAIN][entry.entry_id]
+    created: set[str] = set()
+
+    def _ensure_person(slug: str) -> None:
+        if slug in created:
+            return
+        created.add(slug)
+        async_add_entities(
+            [
+                NextAlarmSensor(coordinator, slug),
+                NextAlarmDiagnosticsSensor(coordinator, slug),
+            ]
+        )
+
+    remove = coordinator.async_add_person_listener(_ensure_person)
+    entry.async_on_unload(remove)
+
+
+def _note_text(state: PersonState | None) -> str | None:
+    if state is None:
+        return NOTE_MESSAGES["waiting"]
+    if state.note is None:
+        return None
+    return NOTE_MESSAGES.get(state.note, state.note)
+
+
+class NextAlarmSensor(RestoreEntity, SensorEntity):
+    """Represents the next alarm timestamp."""
+
+    _attr_should_poll = False
+    _attr_device_class = SensorDeviceClass.TIMESTAMP
+    _attr_translation_key = "next_alarm"
+    _attr_has_entity_name = True
+
+    def __init__(self, coordinator: NextAlarmCoordinator, slug: str) -> None:
+        self._coordinator = coordinator
+        self._slug = slug
+        self.entity_id = f"sensor.{slug}_next_alarm"
+        self._attr_unique_id = f"ha_ios_nextalarm_next_{slug}"
+
+    async def async_added_to_hass(self) -> None:
+        await super().async_added_to_hass()
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass, self._coordinator.signal_person(self._slug), self._handle_update
+            )
+        )
+        self._handle_update()
+
+    @callback
+    def _handle_update(self) -> None:
+        state = self._coordinator.get_person_state(self._slug)
+        if state:
+            self._attr_name = state.person
+        else:
+            self._attr_name = slugify(self._slug)
+        self.async_write_ha_state()
+
+    @property
+    def available(self) -> bool:
+        return self._coordinator.get_person_state(self._slug) is not None
+
+    @property
+    def native_value(self) -> datetime | None:
+        state = self._coordinator.get_person_state(self._slug)
+        return state.next_alarm_time if state else None
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        state = self._coordinator.get_person_state(self._slug)
+        attributes: dict[str, Any] = {
+            "source_person": state.person if state else self._slug,
+            "map_version": state.map_version if state else MAP_VERSION,
+            "weekday_map_locale": state.map_locale if state else None,
+            ATTR_NOTE: _note_text(state),
+        }
+        if state and state.last_event_time:
+            attributes["source_event_time"] = state.last_event_time.isoformat()
+        if state and state.next_alarm_time:
+            attributes["time_until"] = describe_time_until(state.next_alarm_time)
+        if state and state.next_alarm_key:
+            alarm = state.normalized_alarms.get(state.next_alarm_key)
+            if alarm:
+                attributes.update(
+                    {
+                        "label": alarm.label,
+                        "enabled": alarm.enabled,
+                        "repeat": alarm.repeat,
+                        "repeat_days_localized": list(alarm.repeat_days_localized),
+                        "repeat_days_normalized": list(alarm.repeat_days_normalized),
+                        "snooze": alarm.snooze,
+                        "source_alarm_key": alarm.key,
+                    }
+                )
+        if not state or not state.next_alarm_time:
+            attributes.setdefault(ATTR_NOTE, _note_text(state))
+        return attributes
+
+
+class NextAlarmDiagnosticsSensor(RestoreEntity, SensorEntity):
+    """Diagnostics sensor exposing the raw event payload."""
+
+    _attr_should_poll = False
+    _attr_has_entity_name = True
+    _attr_translation_key = "next_alarm_diagnostics"
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    def __init__(self, coordinator: NextAlarmCoordinator, slug: str) -> None:
+        self._coordinator = coordinator
+        self._slug = slug
+        self.entity_id = f"sensor.{slug}_next_alarm_diagnostics"
+        self._attr_unique_id = f"ha_ios_nextalarm_diag_{slug}"
+
+    async def async_added_to_hass(self) -> None:
+        await super().async_added_to_hass()
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass, self._coordinator.signal_person(self._slug), self._handle_update
+            )
+        )
+        self._handle_update()
+
+    @callback
+    def _handle_update(self) -> None:
+        state = self._coordinator.get_person_state(self._slug)
+        if state:
+            self._attr_name = state.person
+        else:
+            self._attr_name = slugify(self._slug)
+        self.async_write_ha_state()
+
+    @property
+    def native_value(self) -> str | None:
+        state = self._coordinator.get_person_state(self._slug)
+        if not state or not state.last_event_time:
+            return None
+        return state.last_event_time.isoformat()
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        state = self._coordinator.get_person_state(self._slug)
+        if not state:
+            return {
+                ATTR_NOTE: _note_text(None),
+                "map_version": MAP_VERSION,
+                "weekday_map_locale": None,
+            }
+        attributes: dict[str, Any] = {
+            ATTR_NOTE: _note_text(state),
+            "map_version": state.map_version,
+            "weekday_map_locale": state.map_locale,
+            "next_alarm_key": state.next_alarm_key,
+            "next_alarm_time": state.next_alarm_time.isoformat()
+            if state.next_alarm_time
+            else None,
+            "source_person": state.person,
+            "parse_errors": list(state.parse_errors),
+            "map_errors": list(state.map_errors),
+            "normalized_preview": build_normalized_preview(
+                state.normalized_alarms, state.schedule
+            ),
+        }
+        if state.raw_event:
+            attributes["event"] = state.raw_event
+        return attributes

--- a/custom_components/ha_ios_nextalarm/translations/en.json
+++ b/custom_components/ha_ios_nextalarm/translations/en.json
@@ -1,0 +1,39 @@
+{
+  "config": {
+    "flow_title": "HA iOS NextAlarm",
+    "step": {
+      "user": {
+        "title": "Set up HA iOS NextAlarm",
+        "description": "Confirm to start listening for iOS Next Alarm events."
+      }
+    },
+    "abort": {
+      "single_instance_allowed": "Only one HA iOS NextAlarm integration can be configured."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "HA iOS NextAlarm options",
+        "description": "Adjust how weekday names from the shortcut are interpreted.",
+        "data": {
+          "weekday_locale": "Weekday locale",
+          "weekday_custom_map": "Custom weekday map (JSON)"
+        }
+      }
+    },
+    "error": {
+      "invalid_custom_map": "Custom weekday map must be valid JSON without validation errors."
+    }
+  },
+  "entity": {
+    "sensor": {
+      "next_alarm": {
+        "name": "Next alarm"
+      },
+      "next_alarm_diagnostics": {
+        "name": "Next alarm diagnostics"
+      }
+    }
+  }
+}

--- a/custom_components/ha_ios_nextalarm/translations/pl.json
+++ b/custom_components/ha_ios_nextalarm/translations/pl.json
@@ -1,0 +1,39 @@
+{
+  "config": {
+    "flow_title": "HA iOS NextAlarm",
+    "step": {
+      "user": {
+        "title": "Konfiguracja HA iOS NextAlarm",
+        "description": "Zatwierdź, aby rozpocząć nasłuchiwanie zdarzeń Next Alarm z iOS."
+      }
+    },
+    "abort": {
+      "single_instance_allowed": "Można skonfigurować tylko jedną integrację HA iOS NextAlarm."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Opcje HA iOS NextAlarm",
+        "description": "Dostosuj interpretację nazw dni tygodnia z automatyzacji.",
+        "data": {
+          "weekday_locale": "Mapa dni tygodnia",
+          "weekday_custom_map": "Niestandardowa mapa dni tygodnia (JSON)"
+        }
+      }
+    },
+    "error": {
+      "invalid_custom_map": "Mapa dni tygodnia musi być prawidłowym JSON-em bez błędów."
+    }
+  },
+  "entity": {
+    "sensor": {
+      "next_alarm": {
+        "name": "Następny alarm"
+      },
+      "next_alarm_diagnostics": {
+        "name": "Diagnostyka alarmów"
+      }
+    }
+  }
+}

--- a/homeassistant/__init__.py
+++ b/homeassistant/__init__.py
@@ -1,0 +1,3 @@
+"""Minimal Home Assistant stubs for testing."""
+
+__all__ = []

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -1,0 +1,57 @@
+"""Minimal ConfigEntry implementation for tests."""
+
+from __future__ import annotations
+
+from typing import Any, Callable
+
+
+class ConfigEntry:
+    """Simple config entry stub."""
+
+    def __init__(
+        self,
+        *,
+        entry_id: str = "test-entry",
+        domain: str = "",
+        data: dict[str, Any] | None = None,
+        options: dict[str, Any] | None = None,
+    ) -> None:
+        self.entry_id = entry_id
+        self.domain = domain
+        self.data = data or {}
+        self.options = options or {}
+        self._unload_callbacks: list[Callable[[], None]] = []
+
+    def add_update_listener(self, listener: Callable[[Any, "ConfigEntry"], Any]) -> Callable[[], None]:
+        """Register a listener and return a remover."""
+
+        def remove() -> None:
+            if remove in self._unload_callbacks:
+                self._unload_callbacks.remove(remove)
+
+        self._unload_callbacks.append(remove)
+        return remove
+
+    def async_on_unload(self, callback: Callable[[], None]) -> None:
+        """Register a callback to invoke on unload."""
+
+        self._unload_callbacks.append(callback)
+
+    async def async_unload(self) -> None:
+        """Invoke unload callbacks."""
+
+        for callback in list(self._unload_callbacks):
+            callback()
+
+
+class ConfigEntries:
+    """Placeholder for hass.config_entries."""
+
+    async def async_forward_entry_setups(self, entry: ConfigEntry, platforms: list[str]) -> None:
+        return None
+
+    async def async_unload_platforms(self, entry: ConfigEntry, platforms: list[str]) -> bool:
+        return True
+
+    async def async_reload(self, entry_id: str) -> None:
+        return None

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -1,0 +1,19 @@
+"""Home Assistant constants for tests."""
+
+from __future__ import annotations
+
+from enum import Enum
+
+EVENT_TIME_CHANGED = "time_changed"
+
+
+class Platform(str, Enum):
+    """Supported platforms."""
+
+    SENSOR = "sensor"
+
+
+class EntityCategory(str, Enum):
+    """Entity categories."""
+
+    DIAGNOSTIC = "diagnostic"

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -1,0 +1,98 @@
+"""Minimal Home Assistant core constructs for tests."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from datetime import datetime
+from enum import Enum
+from typing import Any, Awaitable, Callable
+
+from .config_entries import ConfigEntries
+from .const import EVENT_TIME_CHANGED
+
+CALLBACK_TYPE = Callable[[], None]
+
+
+def callback(func: Callable) -> Callable:
+    """Return function unchanged."""
+
+    return func
+
+
+class EventOrigin(str, Enum):
+    """Origin of an event."""
+
+    local = "LOCAL"
+    remote = "REMOTE"
+
+
+@dataclass
+class Context:
+    """Context information for events."""
+
+    id: str | None = None
+    user_id: str | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        return {"id": self.id, "user_id": self.user_id}
+
+
+class Event:
+    """Representation of an event."""
+
+    def __init__(
+        self,
+        event_type: str,
+        data: dict[str, Any] | None = None,
+        origin: EventOrigin = EventOrigin.local,
+        time_fired: datetime | None = None,
+        context: Context | None = None,
+    ) -> None:
+        self.event_type = event_type
+        self.data = data or {}
+        self.origin = origin
+        self.time_fired = time_fired or datetime.utcnow()
+        self.context = context or Context()
+
+
+class EventBus:
+    """Simple asynchronous event bus."""
+
+    def __init__(self, hass: "HomeAssistant") -> None:
+        self._hass = hass
+        self._listeners: dict[str, list[Callable[[Event], Any]]] = {}
+
+    def async_listen(self, event_type: str, listener: Callable[[Event], Any]) -> CALLBACK_TYPE:
+        listeners = self._listeners.setdefault(event_type, [])
+        listeners.append(listener)
+
+        def remove() -> None:
+            if listener in listeners:
+                listeners.remove(listener)
+
+        return remove
+
+    def async_fire(self, event_type: str, data: dict[str, Any] | None = None) -> None:
+        event = Event(event_type, data)
+        for listener in list(self._listeners.get(event_type, [])):
+            result = listener(event)
+            if asyncio.iscoroutine(result) or isinstance(result, Awaitable):
+                self._hass.loop.create_task(result)
+
+
+class HomeAssistant:
+    """Simplified Home Assistant instance for tests."""
+
+    def __init__(self) -> None:
+        self.loop = asyncio.get_event_loop()
+        self.data: dict[str, Any] = {}
+        self.config = type("Config", (), {"time_zone": "UTC"})()
+        self.bus = EventBus(self)
+        self.config_entries = ConfigEntries()
+
+    async def async_block_till_done(self) -> None:
+        await asyncio.sleep(0)
+
+    def async_create_task(self, coro: Awaitable[Any]) -> asyncio.Task:
+        return self.loop.create_task(coro)

--- a/homeassistant/helpers/__init__.py
+++ b/homeassistant/helpers/__init__.py
@@ -1,0 +1,1 @@
+"""Helper package."""

--- a/homeassistant/helpers/dispatcher.py
+++ b/homeassistant/helpers/dispatcher.py
@@ -1,0 +1,26 @@
+"""Simple dispatcher helpers for tests."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Callable
+
+from ..core import HomeAssistant
+
+
+def async_dispatcher_connect(hass: HomeAssistant, signal: str, target: Callable[..., Any]) -> Callable[[], None]:
+    listeners = hass.data.setdefault("_dispatcher", {}).setdefault(signal, [])
+    listeners.append(target)
+
+    def remove() -> None:
+        if target in listeners:
+            listeners.remove(target)
+
+    return remove
+
+
+def async_dispatcher_send(hass: HomeAssistant, signal: str, *args: Any) -> None:
+    for callback in list(hass.data.setdefault("_dispatcher", {}).get(signal, [])):
+        result = callback(*args)
+        if asyncio.iscoroutine(result):
+            hass.loop.create_task(result)

--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -1,0 +1,29 @@
+"""Event helpers for tests."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime
+from typing import Any, Callable
+
+from ..const import EVENT_TIME_CHANGED
+from ..core import HomeAssistant
+
+
+def async_track_point_in_time(
+    hass: HomeAssistant, action: Callable[[datetime], Any], point_in_time: datetime
+) -> Callable[[], None]:
+    """Track a moment in time using the time changed event."""
+
+    def _listener(event) -> None:
+        now = event.data.get("now")
+        if now is None:
+            return
+        if now >= point_in_time:
+            remove()
+            result = action(now)
+            if asyncio.iscoroutine(result):
+                hass.loop.create_task(result)
+
+    remove = hass.bus.async_listen(EVENT_TIME_CHANGED, _listener)
+    return remove

--- a/homeassistant/helpers/storage.py
+++ b/homeassistant/helpers/storage.py
@@ -1,0 +1,22 @@
+"""Storage helper for tests."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ..core import HomeAssistant
+
+
+class Store:
+    """Simplified data store using in-memory storage."""
+
+    def __init__(self, hass: HomeAssistant, version: int, key: str) -> None:
+        self.hass = hass
+        self.version = version
+        self.key = key
+
+    async def async_load(self) -> Any:
+        return self.hass.data.setdefault("_store", {}).get(self.key)
+
+    async def async_save(self, data: Any) -> None:
+        self.hass.data.setdefault("_store", {})[self.key] = data

--- a/homeassistant/util/__init__.py
+++ b/homeassistant/util/__init__.py
@@ -1,0 +1,1 @@
+"""Utility package."""

--- a/homeassistant/util/dt.py
+++ b/homeassistant/util/dt.py
@@ -1,0 +1,39 @@
+"""Datetime helpers."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from zoneinfo import ZoneInfo
+
+UTC = timezone.utc
+DEFAULT_TIME_ZONE = UTC
+
+
+def utcnow() -> datetime:
+    return datetime.now(tz=UTC)
+
+
+def parse_datetime(value) -> datetime | None:
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value if value.tzinfo else value.replace(tzinfo=UTC)
+    if isinstance(value, str):
+        text = value.strip()
+        if text.endswith("Z"):
+            text = text[:-1] + "+00:00"
+        try:
+            dt = datetime.fromisoformat(text)
+        except ValueError:
+            return None
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=UTC)
+        return dt
+    return None
+
+
+def get_time_zone(name: str) -> ZoneInfo:
+    try:
+        return ZoneInfo(name)
+    except Exception:
+        return ZoneInfo("UTC")

--- a/homeassistant/util/slugify.py
+++ b/homeassistant/util/slugify.py
@@ -1,0 +1,13 @@
+"""Simple slugify implementation."""
+
+from __future__ import annotations
+
+import re
+
+_slugify_strip_re = re.compile(r"[^\w]+")
+
+
+def slugify(text: str) -> str:
+    text = text or ""
+    text = _slugify_strip_re.sub("_", text).strip("_")
+    return text.lower()

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,0 +1,209 @@
+"""Tests for the NextAlarm coordinator."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+import asyncio
+
+from homeassistant.const import EVENT_TIME_CHANGED
+from homeassistant.core import Context, Event, EventOrigin, HomeAssistant
+from homeassistant.util import dt as dt_util
+
+from custom_components.ha_ios_nextalarm.const import (
+    DEFAULT_OPTIONS,
+    DOMAIN,
+    EVENT_NEXT_ALARM,
+)
+from custom_components.ha_ios_nextalarm.coordinator import NextAlarmCoordinator
+
+
+class MockConfigEntry:
+    """Simplified stand-in for Home Assistant's ConfigEntry."""
+
+    def __init__(self, *, domain: str, data: dict | None = None, options: dict | None = None) -> None:
+        self.domain = domain
+        self.data = data or {}
+        self.options = options or {}
+        self.entry_id = "test-entry"
+
+    def add_to_hass(self, hass) -> None:
+        hass.data.setdefault(self.domain, {})
+
+
+async def async_fire_time_changed(hass, when) -> None:
+    """Fire a time changed event for the provided timestamp."""
+
+    hass.bus.async_fire(EVENT_TIME_CHANGED, {"now": when})
+    await hass.async_block_till_done()
+
+EVENT_DATA = {
+    "alarms": {
+        "1": {
+            "Date": "18.09.2025 05:15",
+            "Label": "Alarm",
+            "Repeat": "on",
+            "Repeat Days": "Wtorek\nPoniedziałek\nŚroda\nCzwartek\nPiątek",
+            "Snooze": "on",
+            "State": "on",
+        },
+        "2": {
+            "Date": "18.09.2025 05:25",
+            "Label": "Alarm",
+            "Repeat": "on",
+            "Repeat Days": "Środa\nWtorek\nPoniedziałek\nCzwartek\nPiątek",
+            "Snooze": "on",
+            "State": "off",
+        },
+        "3": {
+            "Date": "18.09.2025 06:40",
+            "Label": "Alarm",
+            "Repeat": "off",
+            "Repeat Days": "",
+            "Snooze": "on",
+            "State": "off",
+        },
+        "4": {
+            "Date": "18.09.2025 08:30",
+            "Label": "Alarm",
+            "Repeat": "on",
+            "Repeat Days": "Sobota\nNiedziela",
+            "Snooze": "on",
+            "State": "off",
+        },
+        "5": {
+            "Date": "18.09.2025 09:30",
+            "Label": "Alarm",
+            "Repeat": "on",
+            "Repeat Days": "Niedziela\nPoniedziałek\nWtorek\nŚroda\nCzwartek\nPiątek\nSobota",
+            "Snooze": "on",
+            "State": "off",
+        },
+        "6": {
+            "Date": "18.09.2025 12:00",
+            "Label": "Alarm",
+            "Repeat": "off",
+            "Repeat Days": "",
+            "Snooze": "on",
+            "State": "off",
+        },
+        "7": {
+            "Date": "18.09.2025 20:05",
+            "Label": "Pizza",
+            "Repeat": "off",
+            "Repeat Days": "",
+            "Snooze": "on",
+            "State": "off",
+        },
+        "8": {
+            "Date": "17.09.2025 20:30",
+            "Label": "Alarm",
+            "Repeat": "off",
+            "Repeat Days": "",
+            "Snooze": "off",
+            "State": "on",
+        },
+        "9": {
+            "Date": "17.09.2025 21:00",
+            "Label": "Alarm",
+            "Repeat": "off",
+            "Repeat Days": "",
+            "Snooze": "on",
+            "State": "off",
+        },
+        "10": {
+            "Date": "17.09.2025 21:30",
+            "Label": "Alarm",
+            "Repeat": "off",
+            "Repeat Days": "",
+            "Snooze": "on",
+            "State": "off",
+        },
+        "11": {
+            "Date": "17.09.2025 21:45",
+            "Label": "Alarm",
+            "Repeat": "off",
+            "Repeat Days": "",
+            "Snooze": "on",
+            "State": "off",
+        },
+        "12": {
+            "Date": "17.09.2025 21:50",
+            "Label": "Alarm",
+            "Repeat": "off",
+            "Repeat Days": "",
+            "Snooze": "on",
+            "State": "off",
+        },
+        "13": {
+            "Date": "17.09.2025 22:10",
+            "Label": "Alarm",
+            "Repeat": "off",
+            "Repeat Days": "",
+            "Snooze": "on",
+            "State": "off",
+        },
+    },
+    "person": "andrzej",
+}
+
+EVENT_TIME = "2025-09-17T18:16:18.576523+00:00"
+
+
+def test_rollover_and_restore() -> None:
+    """Ensure rollover planning persists across restarts."""
+
+    async def _run() -> None:
+        hass = HomeAssistant()
+        hass.config.time_zone = "Europe/Warsaw"
+        entry = MockConfigEntry(domain=DOMAIN, data={}, options=dict(DEFAULT_OPTIONS))
+        entry.add_to_hass(hass)
+
+        coordinator = NextAlarmCoordinator(hass, entry)
+        await coordinator.async_setup()
+
+        event_payload = deepcopy(EVENT_DATA)
+        event = Event(
+            EVENT_NEXT_ALARM,
+            data=event_payload,
+            origin=EventOrigin.remote,
+            time_fired=dt_util.parse_datetime(EVENT_TIME),
+            context=Context(id="ctx", user_id="user"),
+        )
+        await coordinator._async_process_event(event)
+        await hass.async_block_till_done()
+
+        state = coordinator.get_person_state("andrzej")
+        assert state is not None
+        assert state.next_alarm_time is not None
+        first_next = state.next_alarm_time
+        assert first_next.isoformat().startswith("2025-09-18T05:15")
+
+        original_utcnow = dt_util.utcnow
+        try:
+            dt_util.utcnow = lambda: first_next
+
+            await async_fire_time_changed(hass, first_next)
+            await hass.async_block_till_done()
+
+            state = coordinator.get_person_state("andrzej")
+            assert state is not None
+            assert state.next_alarm_time is not None
+            second_next = state.next_alarm_time
+            assert second_next > first_next
+            assert second_next.isoformat().startswith("2025-09-19T05:15")
+
+            dt_util.utcnow = lambda: second_next
+            await coordinator.async_unload()
+
+            new_coordinator = NextAlarmCoordinator(hass, entry)
+            await new_coordinator.async_setup()
+            await hass.async_block_till_done()
+            new_state = new_coordinator.get_person_state("andrzej")
+            assert new_state is not None
+            assert new_state.next_alarm_time == second_next
+
+            await new_coordinator.async_unload()
+        finally:
+            dt_util.utcnow = original_utcnow
+
+    asyncio.run(_run())

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,0 +1,129 @@
+"""Tests for helper utilities."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from homeassistant.util import dt as dt_util
+
+from custom_components.ha_ios_nextalarm import helpers
+
+
+def test_parse_alarm_datetime_24h() -> None:
+    tz = dt_util.get_time_zone("Europe/Warsaw")
+    result = helpers.parse_alarm_datetime("18.09.2025 05:15", tz)
+    assert result.tzinfo == tz
+    assert result.hour == 5
+    assert result.minute == 15
+    assert result.isoformat().endswith("+02:00")
+
+
+def test_parse_on_off_conversion() -> None:
+    errors: list[str] = []
+    assert helpers.parse_on_off("on", field="State", alarm_key="1", errors=errors) is True
+    assert helpers.parse_on_off("off", field="State", alarm_key="1", errors=errors) is False
+    assert helpers.parse_on_off("ON", field="State", alarm_key="1", errors=errors) is True
+    assert helpers.parse_on_off("unexpected", field="State", alarm_key="2", errors=errors) is None
+    assert errors[-1].startswith("Alarm 2")
+
+
+def test_normalize_repeat_days_polish() -> None:
+    maps, map_errors = helpers.build_weekday_maps("")
+    assert not map_errors
+    parse_errors: list[str] = []
+    localized, normalized, locale = helpers.normalize_repeat_days(
+        "Wtorek\nPoniedziałek\nŚroda\nCzwartek\nPiątek",
+        alarm_key="1",
+        locale_option="auto",
+        maps=maps,
+        errors=parse_errors,
+    )
+    assert locale == "pl"
+    assert normalized == [1, 0, 2, 3, 4]
+    assert localized == [
+        "Wtorek",
+        "Poniedziałek",
+        "Środa",
+        "Czwartek",
+        "Piątek",
+    ]
+    assert not parse_errors
+
+
+def test_normalize_repeat_days_english() -> None:
+    maps, map_errors = helpers.build_weekday_maps("")
+    assert not map_errors
+    parse_errors: list[str] = []
+    localized, normalized, locale = helpers.normalize_repeat_days(
+        "Monday\nSunday",
+        alarm_key="1",
+        locale_option="auto",
+        maps=maps,
+        errors=parse_errors,
+    )
+    assert locale == "en"
+    assert normalized == [0, 6]
+    assert localized == ["Monday", "Sunday"]
+    assert not parse_errors
+
+
+def _alarm(
+    *,
+    key: str,
+    enabled: bool,
+    repeat: bool,
+    base_time: datetime,
+    repeat_days: list[int] | None = None,
+) -> helpers.NormalizedAlarm:
+    return helpers.NormalizedAlarm(
+        key=key,
+        label=f"Alarm {key}",
+        enabled=enabled,
+        repeat=repeat,
+        snooze=False,
+        base_time=base_time,
+        repeat_days_localized=["test"] if repeat and repeat_days else [],
+        repeat_days_normalized=repeat_days or [],
+    )
+
+
+def test_compute_next_alarm_tie_prefers_lower_key() -> None:
+    tz = dt_util.get_time_zone("Europe/Warsaw")
+    base = helpers.parse_alarm_datetime("18.09.2025 05:15", tz)
+    alarms = {
+        "2": _alarm(key="2", enabled=True, repeat=False, base_time=base),
+        "1": _alarm(key="1", enabled=True, repeat=False, base_time=base),
+    }
+    now = helpers.parse_alarm_datetime("17.09.2025 20:00", tz)
+    result = helpers.compute_next_alarm(alarms, now, tz)
+    assert result.alarm is not None
+    assert result.alarm.key == "1"
+    assert result.next_time == base
+
+
+def test_compute_next_alarm_no_future() -> None:
+    tz = dt_util.get_time_zone("Europe/Warsaw")
+    past = helpers.parse_alarm_datetime("17.09.2025 05:15", tz)
+    alarms = {"1": _alarm(key="1", enabled=True, repeat=False, base_time=past)}
+    now = helpers.parse_alarm_datetime("18.09.2025 05:15", tz)
+    result = helpers.compute_next_alarm(alarms, now, tz)
+    assert result.next_time is None
+    assert result.note == "no_future"
+
+
+def test_repeating_alarm_schedule() -> None:
+    tz = dt_util.get_time_zone("Europe/Warsaw")
+    base = helpers.parse_alarm_datetime("18.09.2025 05:15", tz)
+    alarms = {
+        "1": _alarm(
+            key="1",
+            enabled=True,
+            repeat=True,
+            base_time=base,
+            repeat_days=[0, 1, 2, 3, 4],
+        )
+    }
+    now = helpers.parse_alarm_datetime("17.09.2025 18:00", tz)
+    result = helpers.compute_next_alarm(alarms, now, tz)
+    assert result.next_time is not None
+    assert result.next_time.isoformat().startswith("2025-09-18T05:15")


### PR DESCRIPTION
## Summary
- implement an async HA iOS NextAlarm coordinator that normalizes events, tracks per-person state, and persists upcoming alarms with rollover scheduling
- expose next alarm and diagnostics sensors plus a config/option flow with customizable weekday mappings and human-friendly attributes
- add helper utilities, lightweight Home Assistant stubs for tests, and pytest coverage for parsing, scheduling, and persistence logic

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cafd675b28832e92a2db3aad61af47