### PR TITLE
Harden config flow and add UI coverage

### DIFF
--- a/custom_components/ha_ios_nextalarm/translations/en.json
+++ b/custom_components/ha_ios_nextalarm/translations/en.json
@@ -8,7 +8,8 @@
       }
     },
     "abort": {
-      "single_instance_allowed": "Only one HA iOS NextAlarm integration can be configured."
+      "single_instance_allowed": "Only one HA iOS NextAlarm integration can be configured.",
+      "already_configured": "Only one HA iOS NextAlarm integration can be configured."
     }
   },
   "options": {

--- a/custom_components/ha_ios_nextalarm/translations/pl.json
+++ b/custom_components/ha_ios_nextalarm/translations/pl.json
@@ -8,7 +8,8 @@
       }
     },
     "abort": {
-      "single_instance_allowed": "Można skonfigurować tylko jedną integrację HA iOS NextAlarm."
+      "single_instance_allowed": "Można skonfigurować tylko jedną integrację HA iOS NextAlarm.",
+      "already_configured": "Można skonfigurować tylko jedną integrację HA iOS NextAlarm."
     }
   },
   "options": {

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -1,8 +1,34 @@
-"""Minimal ConfigEntry implementation for tests."""
+"""Minimal ConfigEntry and ConfigFlow implementations for tests."""
 
 from __future__ import annotations
 
 from typing import Any, Callable
+
+from .data_entry_flow import FlowResult, FlowResultType
+
+
+class FlowHandler:
+    """Shared helpers for flow handlers."""
+
+    def __init__(self) -> None:
+        self.hass = None
+
+    def async_show_form(
+        self,
+        *,
+        step_id: str,
+        data_schema: Any | None = None,
+        errors: dict[str, str] | None = None,
+    ) -> FlowResult:
+        return {
+            "type": FlowResultType.FORM,
+            "step_id": step_id,
+            "data_schema": data_schema,
+            "errors": errors or {},
+        }
+
+    def async_abort(self, *, reason: str) -> FlowResult:
+        return {"type": FlowResultType.ABORT, "reason": reason}
 
 
 class ConfigEntry:
@@ -15,11 +41,13 @@ class ConfigEntry:
         domain: str = "",
         data: dict[str, Any] | None = None,
         options: dict[str, Any] | None = None,
+        unique_id: str | None = None,
     ) -> None:
         self.entry_id = entry_id
         self.domain = domain
         self.data = data or {}
         self.options = options or {}
+        self.unique_id = unique_id
         self._unload_callbacks: list[Callable[[], None]] = []
 
     def add_update_listener(self, listener: Callable[[Any, "ConfigEntry"], Any]) -> Callable[[], None]:
@@ -44,13 +72,86 @@ class ConfigEntry:
             callback()
 
 
+class ConfigFlow(FlowHandler):
+    """Config flow stub mirroring Home Assistant behaviour closely enough for tests."""
+
+    domain: str = ""
+
+    def __init_subclass__(cls, *, domain: str | None = None, **kwargs: Any) -> None:
+        super().__init_subclass__(**kwargs)
+        if domain is not None:
+            cls.domain = domain
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.context: dict[str, Any] = {}
+        self._unique_id: str | None = None
+
+    async def async_set_unique_id(self, unique_id: str) -> None:
+        self._unique_id = unique_id
+
+    def _async_current_entries(self) -> list[ConfigEntry]:
+        if self.hass is None:
+            return []
+        return [
+            entry
+            for entry in getattr(self.hass.config_entries, "_entries", [])
+            if entry.domain == self.domain
+        ]
+
+    def _abort_if_unique_id_configured(self) -> FlowResult | None:
+        if self._async_current_entries():
+            # Return the same structure Home Assistant would generate when a duplicate unique ID is encountered.
+            return self.async_abort(reason="already_configured")
+        return None
+
+    def async_create_entry(
+        self,
+        *,
+        title: str,
+        data: dict[str, Any],
+        options: dict[str, Any] | None = None,
+    ) -> FlowResult:
+        entry = ConfigEntry(
+            domain=self.domain,
+            data=data,
+            options=options or {},
+            unique_id=self._unique_id,
+        )
+        if self.hass is not None:
+            self.hass.config_entries._entries.append(entry)
+        return {
+            "type": FlowResultType.CREATE_ENTRY,
+            "title": title,
+            "data": data,
+            "options": options or {},
+        }
+
+
+class OptionsFlow(FlowHandler):
+    """Options flow stub used by tests."""
+
+    def __init__(self, config_entry: ConfigEntry) -> None:
+        super().__init__()
+        self.config_entry = config_entry
+
+    def async_create_entry(self, *, data: dict[str, Any]) -> FlowResult:
+        self.config_entry.options = data
+        return {"type": FlowResultType.CREATE_ENTRY, "data": data}
+
+
 class ConfigEntries:
     """Placeholder for hass.config_entries."""
+
+    def __init__(self) -> None:
+        self._entries: list[ConfigEntry] = []  # Track entries so unique ID guards can inspect configured items.
 
     async def async_forward_entry_setups(self, entry: ConfigEntry, platforms: list[str]) -> None:
         return None
 
     async def async_unload_platforms(self, entry: ConfigEntry, platforms: list[str]) -> bool:
+        if entry in self._entries:
+            self._entries.remove(entry)
         return True
 
     async def async_reload(self, entry_id: str) -> None:

--- a/homeassistant/data_entry_flow.py
+++ b/homeassistant/data_entry_flow.py
@@ -1,0 +1,24 @@
+"""Minimal data entry flow helpers for tests."""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any, Dict
+
+FlowResult = Dict[str, Any]
+
+
+class FlowResultType(str, Enum):
+    """Mirror of Home Assistant's flow result types."""
+
+    FORM = "form"
+    CREATE_ENTRY = "create_entry"
+    ABORT = "abort"
+
+
+class AbortFlow(Exception):
+    """Exception raised when a flow is aborted."""
+
+    def __init__(self, reason: str) -> None:
+        super().__init__(reason)
+        self.reason = reason

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import asyncio
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+
+from custom_components.ha_ios_nextalarm.config_flow import (
+    NextAlarmConfigFlow,
+    NextAlarmOptionsFlow,
+)
+from custom_components.ha_ios_nextalarm.const import (
+    CONF_WEEKDAY_CUSTOM_MAP,
+    CONF_WEEKDAY_LOCALE,
+    DEFAULT_OPTIONS,
+    DOMAIN,
+)
+
+
+def test_user_flow_creates_entry() -> None:
+    """Ensure the user step renders cleanly and creates the entry without UI errors."""
+
+    async def _run() -> None:
+        hass = HomeAssistant()
+        flow = NextAlarmConfigFlow()
+        flow.hass = hass
+
+        form = await flow.async_step_user()
+        assert form["type"] == FlowResultType.FORM
+        assert form["errors"] == {}
+        assert form["data_schema"] is not None
+
+        created = await flow.async_step_user({})
+        assert created["type"] == FlowResultType.CREATE_ENTRY
+        assert created["title"] == "HA iOS NextAlarm"
+        assert created["data"] == {}
+        assert created["options"] == DEFAULT_OPTIONS
+        assert hass.config_entries._entries  # type: ignore[attr-defined]
+
+        duplicate_flow = NextAlarmConfigFlow()
+        duplicate_flow.hass = hass
+        abort = await duplicate_flow.async_step_user()
+        assert abort["type"] == FlowResultType.ABORT
+        assert abort["reason"] in {"single_instance_allowed", "already_configured"}
+
+    asyncio.run(_run())
+
+
+def test_options_flow_validates_custom_map() -> None:
+    """Validate that options flow surfaces JSON issues and stores confirmed values."""
+
+    async def _run() -> None:
+        entry = ConfigEntry(domain=DOMAIN, data={}, options=dict(DEFAULT_OPTIONS))
+        flow = NextAlarmOptionsFlow(entry)
+        hass = HomeAssistant()
+        flow.hass = hass
+
+        invalid = await flow.async_step_init(
+            {
+                CONF_WEEKDAY_LOCALE: "en",
+                CONF_WEEKDAY_CUSTOM_MAP: "not json",
+            }
+        )
+        assert invalid["type"] == FlowResultType.FORM
+        assert invalid["errors"] == {"base": "invalid_custom_map"}
+        assert entry.options == DEFAULT_OPTIONS
+
+        valid = await flow.async_step_init(
+            {
+                CONF_WEEKDAY_LOCALE: "pl",
+                CONF_WEEKDAY_CUSTOM_MAP: DEFAULT_OPTIONS[CONF_WEEKDAY_CUSTOM_MAP],
+            }
+        )
+        assert valid["type"] == FlowResultType.CREATE_ENTRY
+        assert entry.options[CONF_WEEKDAY_LOCALE] == "pl"
+        assert (
+            entry.options[CONF_WEEKDAY_CUSTOM_MAP]
+            == DEFAULT_OPTIONS[CONF_WEEKDAY_CUSTOM_MAP]
+        )
+
+    asyncio.run(_run())

--- a/voluptuous.py
+++ b/voluptuous.py
@@ -1,0 +1,47 @@
+"""Lightweight voluptuous stand-in for tests."""
+
+from __future__ import annotations
+
+from typing import Any, Iterable
+
+
+class Schema:
+    """Store the provided schema definition without enforcing validation."""
+
+    def __init__(self, schema: Any) -> None:
+        self.schema = schema
+
+    def __call__(self, data: Any) -> Any:
+        return data
+
+
+class _Marker(str):
+    """Simple marker object carrying a default value attribute."""
+
+    def __new__(cls, value: str, default: Any | None = None) -> "_Marker":
+        obj = str.__new__(cls, value)
+        obj.default = default
+        return obj
+
+
+def Required(value: str, default: Any | None = None) -> _Marker:
+    return _Marker(value, default)
+
+
+def Optional(value: str, default: Any | None = None) -> _Marker:
+    return _Marker(value, default)
+
+
+class In:
+    """Minimal validator placeholder."""
+
+    def __init__(self, options: Iterable[Any]) -> None:
+        self.options = list(options)
+
+    def __contains__(self, value: Any) -> bool:
+        return value in self.options
+
+    def __call__(self, value: Any) -> Any:
+        if value not in self.options:
+            raise ValueError(f"{value!r} not in options")
+        return value


### PR DESCRIPTION
## Summary
- ensure the config flow registers a unique ID, surfaces friendly abort messaging, and serves an explicit empty schema to keep the UI error free
- translate the core already_configured abort reason alongside the existing single instance message
- extend the lightweight Home Assistant test stubs, provide a voluptuous shim, and add config flow tests so the UI path is exercised end-to-end

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68cbfe762acc832e96697d05b441b6eb