### PR TITLE
Add hacs metadata for HACS compatibility

### DIFF
--- a/custom_components/ha_ios_nextalarm/manifest.json
+++ b/custom_components/ha_ios_nextalarm/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "ha_ios_nextalarm",
   "name": "HA iOS NextAlarm",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "integration_type": "hub",
   "iot_class": "local_push",
   "config_flow": true,

--- a/hacs.json
+++ b/hacs.json
@@ -1,0 +1,7 @@
+{
+  "name": "HA iOS NextAlarm",
+  "content_in_root": false,
+  "render_readme": true,
+  "domains": ["sensor"],
+  "homeassistant": "2024.8.0"
+}


### PR DESCRIPTION
## Summary
- add a hacs.json manifest so HACS recognises the integration metadata without errors
- bump the integration version to 0.1.1 for a new installable release

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cc5b2012dc832e9801e09ad004a72e