### PR TITLE
Fix slugify imports for Home Assistant 2023.12+

### DIFF
--- a/custom_components/ha_ios_nextalarm/coordinator.py
+++ b/custom_components/ha_ios_nextalarm/coordinator.py
@@ -15,7 +15,10 @@ from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.event import async_track_point_in_time
 from homeassistant.helpers.storage import Store
 from homeassistant.util import dt as dt_util
-from homeassistant.util.slugify import slugify
+try:  # Home Assistant 2023.12+
+    from homeassistant.util import slugify
+except ImportError:  # pragma: no cover - fallback for older Home Assistant
+    from homeassistant.util.slugify import slugify
 
 from .const import (
     CONF_WEEKDAY_CUSTOM_MAP,

--- a/custom_components/ha_ios_nextalarm/sensor.py
+++ b/custom_components/ha_ios_nextalarm/sensor.py
@@ -11,7 +11,10 @@ from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.restore_state import RestoreEntity
-from homeassistant.util.slugify import slugify
+try:  # Home Assistant 2023.12+
+    from homeassistant.util import slugify
+except ImportError:  # pragma: no cover - fallback for older Home Assistant
+    from homeassistant.util.slugify import slugify
 
 from .const import ATTR_NOTE, DOMAIN, MAP_VERSION
 from .coordinator import NextAlarmCoordinator, PersonState

--- a/homeassistant/util/__init__.py
+++ b/homeassistant/util/__init__.py
@@ -1,1 +1,5 @@
 """Utility package."""
+
+from .slugify import slugify
+
+__all__ = ["slugify"]


### PR DESCRIPTION
## Summary
- update the NextAlarm coordinator and sensor to import `slugify` from `homeassistant.util` with a fallback for older cores
- re-export `slugify` from the stub `homeassistant.util` package used by tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cc601f9138832eab20d553248c48d3