### PR TITLE
Handle immediate re-setup after removal

### DIFF
--- a/custom_components/ha_ios_nextalarm/__init__.py
+++ b/custom_components/ha_ios_nextalarm/__init__.py
@@ -23,6 +23,7 @@ async def async_setup(hass: HomeAssistant, config: dict) -> bool:
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up HA iOS NextAlarm from a config entry."""
 
+    hass.data.setdefault(DOMAIN, {})
     coordinator = NextAlarmCoordinator(hass, entry)
     await coordinator.async_setup()
     hass.data[DOMAIN][entry.entry_id] = coordinator


### PR DESCRIPTION
## Summary
- ensure the integration storage in `hass.data` is initialized when setting up a config entry to prevent KeyError when re-adding the integration

## Testing
- python -m compileall custom_components/ha_ios_nextalarm

------
https://chatgpt.com/codex/tasks/task_e_68d013ab3974832ebc720111e8d6f634