### PR TITLE
Adjust sensor identifiers and hardening

### DIFF
--- a/custom_components/ha_ios_nextalarm/config_flow.py
+++ b/custom_components/ha_ios_nextalarm/config_flow.py
@@ -70,34 +70,34 @@ class NextAlarmOptionsFlow(config_entries.OptionsFlow):
         current = dict(DEFAULT_OPTIONS)
         current.update(self.config_entry.options)
 
+        form_locale = current[CONF_WEEKDAY_LOCALE]
+        form_map = current[CONF_WEEKDAY_CUSTOM_MAP]
+        maps_preview, _ = helpers.build_weekday_maps(form_map)
+
         if user_input is not None:
-            locale = user_input[CONF_WEEKDAY_LOCALE]
-            custom_map = user_input.get(
+            form_locale = user_input[CONF_WEEKDAY_LOCALE]
+            form_map = user_input.get(
                 CONF_WEEKDAY_CUSTOM_MAP, DEFAULT_OPTIONS[CONF_WEEKDAY_CUSTOM_MAP]
             )
-            _, map_errors = helpers.build_weekday_maps(custom_map)
+            maps_preview, map_errors = helpers.build_weekday_maps(form_map)
             if map_errors:
                 errors["base"] = "invalid_custom_map"
             else:
                 return self.async_create_entry(
                     data={
-                        CONF_WEEKDAY_LOCALE: locale,
-                        CONF_WEEKDAY_CUSTOM_MAP: custom_map,
+                        CONF_WEEKDAY_LOCALE: form_locale,
+                        CONF_WEEKDAY_CUSTOM_MAP: form_map,
                     }
                 )
 
-        locales = list(OPTION_WEEKDAY_LOCALES)
-        if current[CONF_WEEKDAY_LOCALE] not in locales:
-            locales.append(current[CONF_WEEKDAY_LOCALE])
+        locales = sorted({*OPTION_WEEKDAY_LOCALES, *maps_preview.keys(), form_locale})
 
         schema = vol.Schema(
             {
-                vol.Required(CONF_WEEKDAY_LOCALE, default=current[CONF_WEEKDAY_LOCALE]): vol.In(
-                    locales
-                ),
+                vol.Required(CONF_WEEKDAY_LOCALE, default=form_locale): vol.In(locales),
                 vol.Optional(
                     CONF_WEEKDAY_CUSTOM_MAP,
-                    default=current[CONF_WEEKDAY_CUSTOM_MAP],
+                    default=form_map,
                 ): str,
             }
         )

--- a/custom_components/ha_ios_nextalarm/sensor.py
+++ b/custom_components/ha_ios_nextalarm/sensor.py
@@ -105,8 +105,7 @@ class NextAlarmSensor(RestoreEntity, SensorEntity):
     def __init__(self, coordinator: NextAlarmCoordinator, slug: str) -> None:
         self._coordinator = coordinator
         self._slug = slug
-        self.entity_id = f"sensor.{slug}_next_alarm"
-        self._attr_unique_id = f"ha_ios_nextalarm_next_{slug}"
+        self._attr_unique_id = f"{coordinator.entry.entry_id}_{slug}_next"
 
     async def async_added_to_hass(self) -> None:
         await super().async_added_to_hass()
@@ -119,7 +118,6 @@ class NextAlarmSensor(RestoreEntity, SensorEntity):
 
     @callback
     def _handle_update(self) -> None:
-        self._attr_name = _device_name(self._coordinator, self._slug)
         _async_update_device_registry(self.hass, self._coordinator, self._slug)
         self.async_write_ha_state()
 
@@ -183,8 +181,7 @@ class NextAlarmDiagnosticsSensor(RestoreEntity, SensorEntity):
     def __init__(self, coordinator: NextAlarmCoordinator, slug: str) -> None:
         self._coordinator = coordinator
         self._slug = slug
-        self.entity_id = f"sensor.{slug}_next_alarm_diagnostics"
-        self._attr_unique_id = f"ha_ios_nextalarm_diag_{slug}"
+        self._attr_unique_id = f"{coordinator.entry.entry_id}_{slug}_diagnostics"
 
     async def async_added_to_hass(self) -> None:
         await super().async_added_to_hass()
@@ -197,7 +194,6 @@ class NextAlarmDiagnosticsSensor(RestoreEntity, SensorEntity):
 
     @callback
     def _handle_update(self) -> None:
-        self._attr_name = _device_name(self._coordinator, self._slug)
         _async_update_device_registry(self.hass, self._coordinator, self._slug)
         self.async_write_ha_state()
 


### PR DESCRIPTION
## Summary
- align sensor entities with HA registry conventions by relying on unique_id and translation-based names
- allow custom weekday maps to surface as selectable locales in the options flow
- harden alarm normalization by validating payload structures and parsing more datetime formats

## Testing
- python -m compileall custom_components/ha_ios_nextalarm

------
https://chatgpt.com/codex/tasks/task_e_68d0392c7cb8832e9624715dd34a4c3b