### PR TITLE
Fix options flow crash handling and add defensive logging

### DIFF
--- a/custom_components/ha_ios_nextalarm/translations/en.json
+++ b/custom_components/ha_ios_nextalarm/translations/en.json
@@ -19,12 +19,14 @@
         "description": "Adjust how weekday names from the shortcut are interpreted.",
         "data": {
           "weekday_locale": "Weekday locale",
-          "weekday_custom_map": "Custom weekday map (JSON)"
+          "weekday_custom_map": "Custom weekday map (JSON)",
+          "refresh_timeout": "Refresh timeout (minutes)"
         }
       }
     },
     "error": {
-      "invalid_custom_map": "Custom weekday map must be valid JSON without validation errors."
+      "invalid_custom_map": "Custom weekday map must be valid JSON without validation errors.",
+      "unknown": "Unexpected error while loading options. Check the logs for details."
     }
   },
   "entity": {

--- a/custom_components/ha_ios_nextalarm/translations/pl.json
+++ b/custom_components/ha_ios_nextalarm/translations/pl.json
@@ -19,12 +19,14 @@
         "description": "Dostosuj interpretację nazw dni tygodnia z automatyzacji.",
         "data": {
           "weekday_locale": "Mapa dni tygodnia",
-          "weekday_custom_map": "Niestandardowa mapa dni tygodnia (JSON)"
+          "weekday_custom_map": "Niestandardowa mapa dni tygodnia (JSON)",
+          "refresh_timeout": "Limit czasu odświeżania (minuty)"
         }
       }
     },
     "error": {
-      "invalid_custom_map": "Mapa dni tygodnia musi być prawidłowym JSON-em bez błędów."
+      "invalid_custom_map": "Mapa dni tygodnia musi być prawidłowym JSON-em bez błędów.",
+      "unknown": "Nieoczekiwany błąd podczas wczytywania opcji. Sprawdź logi."
     }
   },
   "entity": {


### PR DESCRIPTION
### Motivation
- The options UI could raise a 500 error when stored options or a custom weekday map caused an exception during `async_step_init` parsing. 
- The goal is to ensure the options form always renders and that invalid input surfaces as form errors rather than crashing the backend. 
- Preserve existing behavior and stored options while improving diagnostics for future failures. 

### Description
- Wrap `async_step_init` in a safe entry that logs `user_input` and a snapshot of `config_entry.options` and delegates to an internal `_async_step_init_internal`. 
- Add `_async_show_fallback_form` to present a safe schema using `DEFAULT_OPTIONS` when unexpected errors occur. 
- Improve error logging with `_LOGGER.exception` so the exact failing context is available in Home Assistant logs. 
- Add translations for the `refresh_timeout` field and a generic `unknown` options error in `en.json` and `pl.json`.

### Testing
- Ran `python3 -m compileall custom_components/ha_ios_nextalarm/` and the compilation completed successfully. 
- No additional automated tests were modified or added. 
- The change is limited to options flow handling and translations to avoid breaking existing runtime behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69661ec2acd0832ea96e40bdfc9c252f)